### PR TITLE
Redis state and multi-stream orchestrator

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,3 +11,9 @@ postgres:
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   ports:
     - '${POSTGRES_PORT}:5432'
+
+redis:
+  image: redis:6
+  command: redis-server --appendonly yes
+  ports:
+    - 6379:6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -4761,7 +4761,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "duplexer": {
       "version": "0.1.2",

--- a/packages/ldes-dummy-state/lib/DummyState.ts
+++ b/packages/ldes-dummy-state/lib/DummyState.ts
@@ -20,7 +20,7 @@ export class DummyState implements IState {
     this.pages.push(page);
   }
 
-  public async getProcessedPaged(): Promise<Url[]> {
+  public async getProcessedPages(): Promise<Url[]> {
     return this.pages;
   }
 

--- a/packages/ldes-manager/lib/QueryService.ts
+++ b/packages/ldes-manager/lib/QueryService.ts
@@ -26,7 +26,7 @@ export class QueryService {
     const LDESClient = newEngine();
     const eventstreamSync = LDESClient.createReadStream(config.url, options);
 
-    const orchestrator = new Orchestrator([this.connector], state, eventstreamSync);
+    const orchestrator = new Orchestrator([this.connector], state, [eventstreamSync]);
 
     await orchestrator.provision();
 

--- a/packages/ldes-redis-state/index.ts
+++ b/packages/ldes-redis-state/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/RedisState';

--- a/packages/ldes-redis-state/lib/RedisState.ts
+++ b/packages/ldes-redis-state/lib/RedisState.ts
@@ -1,0 +1,49 @@
+import type { Url } from 'url';
+import type { IState } from '@ldes/types';
+import type { WrappedNodeRedisClient } from 'handy-redis';
+import { createNodeRedisClient } from 'handy-redis';
+
+interface IRedisStateConfig {
+  id: string;
+  host?: string;
+  port?: number;
+  password?: string;
+}
+
+export class RedisState implements IState {
+  private client: WrappedNodeRedisClient;
+  private readonly settings: IRedisStateConfig;
+
+  public constructor(settings: IRedisStateConfig) {
+    this.settings = settings;
+  }
+
+  public async getLatestPage(): Promise<Url | null> {
+    const pages = await this.getProcessedPages();
+
+    return pages.length > 0 ? pages[pages.length - 1] : null;
+  }
+
+  public async setLatestPage(page: Url): Promise<void> {
+    const pages = await this.getProcessedPages();
+    pages.push(page);
+
+    await this.setPages(pages);
+  }
+
+  public async getProcessedPages(): Promise<Url[]> {
+    return JSON.parse((await this.client.get(`ldes_${this.settings.id}_pages`)) ?? '[]');
+  }
+
+  public async provision(): Promise<void> {
+    this.client = createNodeRedisClient({
+      host: this.settings.host ?? '127.0.0.1',
+      port: this.settings.port ?? 6_379,
+      password: this.settings.password,
+    });
+  }
+
+  private async setPages(pages: Url[]): Promise<void> {
+    await this.client.set(`ldes_${this.settings.id}_pages`, JSON.stringify(pages));
+  }
+}

--- a/packages/ldes-redis-state/package-lock.json
+++ b/packages/ldes-redis-state/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "@ldes/ldes-redis-state",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz",
+      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw=="
+    },
+    "@types/redis": {
+      "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
+      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+    },
+    "handy-redis": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/handy-redis/-/handy-redis-2.2.2.tgz",
+      "integrity": "sha512-m+7d89zM/rUVvtvVV0/wQGY2SQOh2fgIgg2Fts9q/wQFom0h5sZTCYPHgzPtnJxDOilIMvxRbPHi7b+IKin7UA==",
+      "requires": {
+        "@types/redis": "^2.8.30"
+      }
+    },
+    "redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    }
+  }
+}

--- a/packages/ldes-redis-state/package.json
+++ b/packages/ldes-redis-state/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ldes/ldes-redis-state",
+  "version": "0.0.0",
+  "description": "> TODO: description",
+  "homepage": "https://github.com/Informatievlaanderen/ldes2service#readme",
+  "license": "ISC",
+  "main": "index.js",
+  "typings": "index",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Informatievlaanderen/ldes2service.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/Informatievlaanderen/ldes2service/issues"
+  },
+  "devDependencies": {
+    "@ldes/types": "^0.0.0"
+  },
+  "dependencies": {
+    "@ldes/types": "^0.0.0",
+    "handy-redis": "^2.2.2",
+    "redis": "^3.1.2"
+  }
+}

--- a/packages/ldes-replicator/.env.example
+++ b/packages/ldes-replicator/.env.example
@@ -1,2 +1,2 @@
-URL=https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/objecten
+URLS=https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/objecten,https://smartdata.dev-vlaanderen.be/base/straatnaam
 POLL_INTERVAL=5000

--- a/packages/ldes-replicator/bin/ldes-replicator.ts
+++ b/packages/ldes-replicator/bin/ldes-replicator.ts
@@ -2,7 +2,7 @@
  * CLI interface where manual dependency injection happens
  */
 
-import { PostgresConnector } from '@ldes/ldes-postgres-connector';
+import { DummyConnector } from '@ldes/ldes-dummy-connector';
 import { RedisState } from '@ldes/ldes-redis-state';
 
 import { newEngine } from '@treecg/actor-init-ldes-client';
@@ -10,11 +10,11 @@ import { Orchestrator } from '../lib/Orchestrator';
 
 // TODO: Parse and use CLI parameters
 
-const URL = process.env.URL;
+const URLS = process.env.URLS;
 const POLL_INTERVAL = Number.parseInt(process.env.pollingInterval ?? '5000', 10);
 
 async function run(): Promise<void> {
-  const connector = new PostgresConnector({ amountOfVersions: 0, databaseName: 'ldes' });
+  const connector = new DummyConnector();
   const state = new RedisState({
     id: 'replicator',
   });
@@ -23,14 +23,15 @@ async function run(): Promise<void> {
     pollingInterval: POLL_INTERVAL,
   };
 
-  if (!URL) {
-    throw new Error('No LDES URL specified. Have you added the URL environment variable?');
+  if (!URLS) {
+    throw new Error('No LDES URLs specified. Have you added the URL environment variable?');
   }
 
   const LDESClient = newEngine();
-  const eventstreamSync = LDESClient.createReadStream(URL, options);
 
-  const orchestrator = new Orchestrator([connector], state, eventstreamSync);
+  const streams = URLS.split(',').map(url => LDESClient.createReadStream(url, options));
+
+  const orchestrator = new Orchestrator([connector], state, streams);
 
   await orchestrator.provision();
   await orchestrator.run();

--- a/packages/ldes-replicator/bin/ldes-replicator.ts
+++ b/packages/ldes-replicator/bin/ldes-replicator.ts
@@ -2,8 +2,8 @@
  * CLI interface where manual dependency injection happens
  */
 
-import { DummyState } from '@ldes/ldes-dummy-state';
 import { PostgresConnector } from '@ldes/ldes-postgres-connector';
+import { RedisState } from '@ldes/ldes-redis-state';
 
 import { newEngine } from '@treecg/actor-init-ldes-client';
 import { Orchestrator } from '../lib/Orchestrator';
@@ -15,7 +15,9 @@ const POLL_INTERVAL = Number.parseInt(process.env.pollingInterval ?? '5000', 10)
 
 async function run(): Promise<void> {
   const connector = new PostgresConnector({ amountOfVersions: 0, databaseName: 'ldes' });
-  const state = new DummyState();
+  const state = new RedisState({
+    id: 'replicator',
+  });
 
   const options = {
     pollingInterval: POLL_INTERVAL,

--- a/packages/ldes-replicator/lib/Orchestrator.ts
+++ b/packages/ldes-replicator/lib/Orchestrator.ts
@@ -7,9 +7,9 @@ import type { IState, IWritableConnector } from '@ldes/types';
 export class Orchestrator {
   private readonly connectors: IWritableConnector[];
   private readonly stateStore: IState;
-  private readonly ldes: Readable;
+  private readonly ldes: Readable[];
 
-  public constructor(connectors: IWritableConnector[], stateStore: IState, ldes: Readable) {
+  public constructor(connectors: IWritableConnector[], stateStore: IState, ldes: Readable[]) {
     this.connectors = connectors;
     this.stateStore = stateStore;
     this.ldes = ldes;
@@ -18,12 +18,16 @@ export class Orchestrator {
   /**
    * Start listening to the events and pipe them to the connectors
    */
-  public async run(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.ldes.on('readable', () => this.processData()).on('error', error => reject(error));
-
-      this.ldes.on('end', () => resolve());
-    });
+  public async run(): Promise<void[]> {
+    return Promise.all(
+      this.ldes.map(
+        ldes =>
+          new Promise<void>((resolve, reject) => {
+            ldes.on('readable', () => this.processData(ldes)).on('error', error => reject(error));
+            ldes.on('end', () => resolve());
+          })
+      )
+    );
   }
 
   public async provision(): Promise<void> {
@@ -40,14 +44,14 @@ export class Orchestrator {
     throw new Error('not implemented');
   }
 
-  protected async processData(): Promise<void> {
-    let member: string = this.ldes.read();
+  protected async processData(ldes: Readable): Promise<void> {
+    let member: string = ldes.read();
 
     while (member) {
       const copiedMember = member;
       await Promise.all(this.connectors.map(con => con.writeVersion(copiedMember)));
 
-      member = this.ldes.read();
+      member = ldes.read();
     }
   }
 }

--- a/packages/ldes-replicator/package.json
+++ b/packages/ldes-replicator/package.json
@@ -33,6 +33,7 @@
     "@comunica/core": "~1.19.2",
     "@ldes/ldes-dummy-connector": "^0.0.0",
     "@ldes/ldes-dummy-state": "^0.0.0",
+    "@ldes/ldes-redis-state": "^0.0.0",
     "@ldes/ldes-postgres-connector": "^0.0.0",
     "@ldes/types": "^0.0.0",
     "@treecg/actor-init-ldes-client": "^2.3.2",

--- a/packages/ldes-types/lib/IState.ts
+++ b/packages/ldes-types/lib/IState.ts
@@ -19,5 +19,5 @@ export interface IState {
   /**
    * Return all processed pages
    */
-  getProcessedPaged: () => Promise<Url[]>;
+  getProcessedPages: () => Promise<Url[]>;
 }


### PR DESCRIPTION
Implements #16 and #42

The Orchestrator now accepts an array of streams to handle, allowing use to follow multiple LDES together.

An implementation of the DummyState has been done with redis in @ldes/ldes-redis-state, to launch a local redis server check the docker-compose.test.yml file.