### PR TITLE
Fixing SHACL handling

### DIFF
--- a/packages/ldes-dummy-connector/lib/DummyConnector.ts
+++ b/packages/ldes-dummy-connector/lib/DummyConnector.ts
@@ -1,4 +1,4 @@
-import type { IConfigConnector, IWritableConnector } from '@ldes/types';
+import type { IConfigConnector, IWritableConnector, LdesShape } from '@ldes/types';
 
 export class DummyConnector implements IWritableConnector {
   private readonly members: any[];
@@ -10,8 +10,10 @@ export class DummyConnector implements IWritableConnector {
 
   public static helmTemplate = ``;
 
-  public constructor(config: IConfigConnector) {
+  public constructor(config: IConfigConnector, shape: LdesShape, id: string) {
     this.members = [];
+    console.log('Shape:');
+    console.dir(shape);
   }
 
   /**

--- a/packages/ldes-replicator/bin/ldes-replicator.ts
+++ b/packages/ldes-replicator/bin/ldes-replicator.ts
@@ -8,7 +8,7 @@ import { RedisState } from '@ldes/ldes-redis-state';
 import type { ConnectorConfigs, LdesObjects, LdesShape } from '@ldes/types';
 import { Command, flags } from '@oclif/command';
 import { newEngine } from '@treecg/actor-init-ldes-client';
-import { DataFactory } from 'n3';
+import { DataFactory, Quad, Store } from 'n3';
 import rdfDereferencer from 'rdf-dereference';
 import { storeStream } from 'rdf-store-stream';
 import slugify from 'slugify';
@@ -39,56 +39,49 @@ async function fetchShape({ ldesURI, shapeURI }: Record<string, any>): Promise<L
   const { quads: ldesQuads } = await rdfDereferencer.dereference(ldesURI);
 
   // This is the store with shacl quads
-  let store;
+  let store: Store = new Store();
 
   // Console.debug('ldesQuads :', ldesQuads);
   if (!shapeURI) {
-    const storeQuads = await storeStream(ldesQuads);
+    const storeQuads: Store = <Store>await storeStream(ldesQuads);
     // Console.debug('storeQuads :', storeQuads);
 
     storeQuads
-      // @ts-expect-error the method exists
-      .getQuads(namedNode(ldesURI), namedNode('https://w3id.org/tree#shape'))
-      .forEach((quad: any) => {
+      .getQuads(namedNode(ldesURI), namedNode('https://w3id.org/tree#shape'), null, null)
+      .forEach((quad: Quad) => {
         if (quad.object.termType === 'BlankNode') store = storeQuads;
         else if (quad.object.termType === 'NamedNode') shapeURI = quad.object.value;
       });
   }
 
-  if (!shapeURI && !store) {
-    //TODO: what should happen when no shape at all was found?
-    console.error('No shape was found for this LDES URI');
-    return [];
-  }
-
   if (!store) {
     const { quads: shapeQuads } = await rdfDereferencer.dereference(shapeURI, { localFiles: true });
-    store = await storeStream(shapeQuads);
+    store = <Store>await storeStream(shapeQuads);
   }
 
   const paths = Object.fromEntries(
     store
-      // @ts-expect-error the method exists
-      .getQuads(undefined, namedNode('https://www.w3.org/ns/shacl#path'))
-      .map((quad: any) => [quad.subject.value, quad])
+      .getQuads(namedNode(shapeURI), namedNode('https://www.w3.org/ns/shacl#property'), null, null)
+      .map((quad: Quad) => {
+        let shaclpropertyURI = quad.object;
+        return store.getQuads(shaclpropertyURI, namedNode('https://www.w3.org/ns/shacl#path'), null, null)[0];
+      })
+      .map((quad: Quad) => [quad.subject.value, quad])
   );
   const datatypes = Object.fromEntries(
     store
-      // @ts-expect-error the method exists
-      .getQuads(undefined, namedNode('https://www.w3.org/ns/shacl#datatype'))
-      .map((quad: any) => [quad.subject.value, quad])
+      .getQuads(null, namedNode('https://www.w3.org/ns/shacl#datatype'), null, null)
+      .map((quad: Quad) => [quad.subject.value, quad])
   );
   const nodeKinds = Object.fromEntries(
     store
-      // @ts-expect-error the method exists
-      .getQuads(undefined, namedNode('https://www.w3.org/ns/shacl#nodeKind'))
-      .map((quad: any) => [quad.subject.value, quad])
+      .getQuads(null, namedNode('https://www.w3.org/ns/shacl#nodeKind'), null, null)
+      .map((quad: Quad) => [quad.subject.value, quad])
   );
   const classes = Object.fromEntries(
     store
-      // @ts-expect-error the method exists
-      .getQuads(undefined, namedNode('https://www.w3.org/ns/shacl#class'))
-      .map((quad: any) => [quad.subject.value, quad])
+      .getQuads(null, namedNode('https://www.w3.org/ns/shacl#class'), null, null)
+      .map((quad: Quad) => [quad.subject.value, quad])
   );
 
   return Object.entries(paths).map(([id, quad]) => ({

--- a/packages/ldes-replicator/bin/ldes-replicator.ts
+++ b/packages/ldes-replicator/bin/ldes-replicator.ts
@@ -40,25 +40,25 @@ async function fetchShape({ ldesURI, shapeURI }: Record<string, any>): Promise<L
 
   // This is the store with shacl quads
   let store;
-  
+
   // Console.debug('ldesQuads :', ldesQuads);
   if (!shapeURI) {
     const storeQuads = await storeStream(ldesQuads);
     // Console.debug('storeQuads :', storeQuads);
-    
+
     storeQuads
       // @ts-expect-error the method exists
       .getQuads(namedNode(ldesURI), namedNode('https://w3id.org/tree#shape'))
       .forEach((quad: any) => {
-        if (quad.object.termType === 'BlankNode')
-          store = storeQuads;
-        else if (quad.object.termType === 'NamedNode')
-          shapeURI = quad.object.value;
+        if (quad.object.termType === 'BlankNode') store = storeQuads;
+        else if (quad.object.termType === 'NamedNode') shapeURI = quad.object.value;
       });
   }
-  
+
   if (!shapeURI && !store) {
-    throw new Error('No shape was found for this LDES URI');
+    //TODO: what should happen when no shape at all was found?
+    console.error('No shape was found for this LDES URI');
+    return [];
   }
 
   if (!store) {


### PR DESCRIPTION
Fixes:
 1. [x] Dummy connector now outputs the schema on stdout
 2. [x] BlankNode shapes should work by just using the current page as quads input
 3. [x] Subject should be checked when extracting the shape
 4. [x] When no Shape could be found, we should return empty array